### PR TITLE
:bug: correctly extract SSH key file extension

### DIFF
--- a/train/vpc/ses.py
+++ b/train/vpc/ses.py
@@ -22,7 +22,7 @@ def prep_file(path, username):
     attachment = MIMEApplication(open(path, 'rb').read())
     attachment.add_header('Content-Disposition',
                           'attachment',
-                          filename='{0}.{1}'.format(username, path.split('.')[1]))
+                          filename='{0}.{1}'.format(username, path.split('.')[-1]))
 
     return(attachment)
 


### PR DESCRIPTION
Was based on absence of '.' in the file path (so in the username or VPC).
Now it doesn't care the number of '.' in the file path.
From: docker-training/train#51